### PR TITLE
Better solution for terminating unused outputs on Issie

### DIFF
--- a/DECA/Part1/Section3.md
+++ b/DECA/Part1/Section3.md
@@ -63,7 +63,7 @@ Set the number of bits of the constant to 4 and the value to 1.
 Connect another constant to the carry input, with a width of 1 and a value of 0.
 
 In Issie, floating ports (inputs/outputs of components that are not connected to anything) are not allowed.
-To solve this, connect the `Cout` port of your full adder to either an output port, or to the `Wire Label` component from the 'Input/Output' section of the catalogue.
+To solve this, add `Not Connected` component from the 'Input/Output' section of the catalogue and then connect the `Cout` port this component to terminate the signal coming out of this port.
             
 Test your counter using the Step Simulation tab.
 Each time you click on the 'Clock Tick N' button, you will see the output value increment by one.


### PR DESCRIPTION
There is no need to use an output port or a wire label to terminate an unused output. There is a component named "Not Connected" under "Input/Output" section of Issie that is exactly used to solve these kind of conflicts.